### PR TITLE
feat: enable sender with different phone formatter

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -11,7 +11,7 @@ class Message
 
     protected string $body;
 
-    protected ?string $sender = null;
+    protected null|string|Phone $sender = null;
 
     protected array $properties = [];
 
@@ -20,13 +20,13 @@ class Message
         $this->body = $body;
     }
 
-    public function withSender(?string $sender): static
+    public function withSender(null|string|Phone $sender): static
     {
         $this->sender = $sender;
         return $this;
     }
 
-    public function getSender(): ?string
+    public function getSender(): null|Phone|string
     {
         return $this->sender;
     }

--- a/src/Provider/TwilioMessagingProvider.php
+++ b/src/Provider/TwilioMessagingProvider.php
@@ -45,8 +45,13 @@ class TwilioMessagingProvider extends ProviderBase
         }
 
         $toStr = $to->withPlusPrefix()->withCountryCode()->hydrate();
-        $from = Phone::phone($envelope->getSender(), $to->getPhoneFormat())->withPlusPrefix()->withCountryCode()->hydrate();
+        if (is_string($envelope->getSender())) {
+            $from = Phone::phone($envelope->getSender(), $to->getPhoneFormat());
+        } else {
+            $from = $envelope->getSender();
+        }
 
+        $from = $from->withPlusPrefix()->withCountryCode()->hydrate();
         $request = RequestFormUrlEncoded::build(
             new Uri("https://api.twilio.com/2010-04-01/Accounts/" . $this->uri->getUsername() . "/Messages.json"),
             [


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Enable the `Message` class to support senders as either `null`, `string`, or a `Phone` object, and adjust the logic in `TwilioMessagingProvider` to handle and format these sender types accordingly.

### Why are these changes being made?

To accommodate different sender formats—string or `Phone` object—in message handling and improve flexibility of the messaging system. This change makes it possible to work with various phone number formats and providers by allowing a `Phone` object to be manipulated directly.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->